### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ The project demonstrates how to interface and use a ToF sensor to measure the di
 ## Installation
  1. Clone the repository:
 ```
-git clone https://github.com/yourusername/stepper-motor-tof-sensor.git
-cd stepper-motor-tof-sensor
+git clone https://github.com/Sohampaul7/Work.git
+cd Work
+
 ```
 2. Install the required library:
     * AccelStepper (for stepper motor control)


### PR DESCRIPTION
Fix Installation Instructions in README

## Description:

### What Changed:

- Corrected the Installation section in the README file to include accurate repository cloning and navigation instructions.

### Why:

- The previous instructions were generic placeholders from a template and did not reflect the repository structure.
#1 can be closed for the dev branch once the PR is accepted